### PR TITLE
Add upstream metadata for SDL2_ttf version 2.24.0

### DIFF
--- a/metadata/S/SDL2_ttf_jll.toml
+++ b/metadata/S/SDL2_ttf_jll.toml
@@ -109,3 +109,7 @@ registered = 2026-03-24T21:59:28.000Z
         hash = "2a891473eaf05ba1707a4b7913e6c4db7de7458a"
         type = "git"
         url = "https://github.com/libsdl-org/SDL_ttf.git"
+
+            ["2.24.0+0".artifact_metadata.sources.upstream]
+            project = "repology.org/project/sdl2-ttf"
+            version = "2.24.0"


### PR DESCRIPTION
https://github.com/libsdl-org/SDL_ttf/releases/tag/release-2.24.0