### PR TITLE
Update NASM version to 3.02rc0 in metadata

### DIFF
--- a/metadata/N/NASM_jll.toml
+++ b/metadata/N/NASM_jll.toml
@@ -80,3 +80,4 @@ registered = 2026-01-14T16:58:33.000Z
 
             ["3.1.0+0".artifact_metadata.sources.upstream]
             project = "repology.org/project/nasm"
+            version = "3.02rc0"


### PR DESCRIPTION
The tagged commit, https://github.com/netwide-assembler/nasm/commit/746e7c9efa37cec9a44d84a1e96b8c38f385cc1f, is one ahead of the one where they set/tag 3.02rc0 (https://github.com/netwide-assembler/nasm/commit/746e7c9efa37cec9a44d84a1e96b8c38f385cc1f).