### PR TITLE
Update bsdiff_classic_jll.toml with upstream info

### DIFF
--- a/metadata/B/bsdiff_classic_jll.toml
+++ b/metadata/B/bsdiff_classic_jll.toml
@@ -35,3 +35,8 @@ registered = 2024-10-25T10:33:31.000Z
         hash = "24b5474a87e495678d71cac7ba02493fb4fa483f"
         type = "git"
         url = "https://salsa.debian.org/debian/bsdiff.git"
+
+            ["4.3.17+0".artifact_metadata.sources.upstream]
+            project = "repology.org/project/bsdiff"
+            version = "4.3"
+


### PR DESCRIPTION
Add upstream project metadata for bsdiff.  This is actually Debian's 4.3-17, which fixes some CVEs