### PR TITLE
Update cJSON version in cJSON_jll.toml

### DIFF
--- a/metadata/C/cJSON_jll.toml
+++ b/metadata/C/cJSON_jll.toml
@@ -17,3 +17,4 @@ registered = 2025-09-02T16:27:27.000Z
 
             ["1.7.18+0".artifact_metadata.sources.upstream]
             project = "repology.org/project/cjson"
+            version = "1.7.18+midrelease"


### PR DESCRIPTION
This isn't really 1.7.18; it's somewhere in-between: https://github.com/DaveGamble/cJSON/compare/v1.7.18...8f2beb57ddad1f94bed899790b00f46df893ccac.  It has a fix for one CVE, but is unfortunately missing another that made it into 1.7.19: https://github.com/DaveGamble/cJSON/compare/8f2beb57ddad1f94bed899790b00f46df893ccac...v1.7.19