### PR TITLE
Update libLAS version in metadata

### DIFF
--- a/metadata/L/libLAS_jll.toml
+++ b/metadata/L/libLAS_jll.toml
@@ -17,6 +17,8 @@ registered = 2021-11-22T22:12:02.000Z
 
             ["0.1.0+0".artifact_metadata.sources.upstream]
             project = "repology.org/project/liblas"
+            version = "1.8.2+midrelease"
+
         [["0.1.0+0".artifact_metadata.sources]]
         type = "directory"
         url = "https://github.com/JuliaPackaging/Yggdrasil/tree/c7de068d0fc8ab1e531bfe36c3d617a7fb8f2a97/L/libLAS/bundled"


### PR DESCRIPTION
Update version in libLAS_jll.toml to 1.8.2 midrelease.

There are extra commits since 1.8.2, and it seems 1.8.2 isn't even tagged... https://github.com/libLAS/libLAS/compare/911cde8ef5dad45e498209c6c176b58472688147...e6a1aaed412d638687b8aec44f7b12df7ca2bbbb