### PR TITLE
Update LuaJIT version in metadata file

### DIFF
--- a/metadata/L/LuaJIT_jll.toml
+++ b/metadata/L/LuaJIT_jll.toml
@@ -17,6 +17,7 @@ registered = 2026-05-19T02:11:01.000Z
 
             ["2.1.20260330+0".artifact_metadata.sources.upstream]
             project = "repology.org/project/luajit"
+            version = "2.1.1774896198"
         [["2.1.20260330+0".artifact_metadata.sources]]
         type = "directory"
         url = "https://github.com/JuliaPackaging/Yggdrasil/tree/4749f48b6ddcc2032fb37d2d3c2bbab16e2a895e/L/LuaJIT/bundled"


### PR DESCRIPTION
LuaJIT's "versioning" is less-than-helpful, but I think this is the most accurate thing we can do.

Cf. https://github.com/JuliaPackaging/Yggdrasil/pull/13750/changes#diff-3bbe94ab27d903bba84aaccc7c1574aa3061792608b60baf411a86e2c5b087dfR10-R14 and https://luajit.org/download.html